### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-default-rules-validity.yml
+++ b/.github/workflows/check-default-rules-validity.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *' # This will run the test every day at midnight
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Kenny1291/cleaner-twitter/security/code-scanning/2](https://github.com/Kenny1291/cleaner-twitter/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's steps, it primarily involves checking out code, setting up Node.js, installing dependencies, running tests, and uploading artifacts. These operations typically require only `contents: read` permissions. We will add this minimal permission to the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
