### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,6 @@
 name: lint
+permissions:
+  contents: read
 on: 
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Kenny1291/cleaner-twitter/security/code-scanning/1](https://github.com/Kenny1291/cleaner-twitter/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to restrict the permissions of the `GITHUB_TOKEN`. Since this is a linting workflow that only reads the repository contents, we will set `contents: read` as the minimal required permission. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
